### PR TITLE
galette_ynh with db engine choice

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -91,9 +91,3 @@ ram.runtime = "50M"
         echo "postgresql, php8.3-pgsql"
        fi
     """
-
-
-# seulement une de ces lignes est possible. Peut-on faire ça par un test ? ou suffit-il d'initialiser la base dans le scriot d'install ?
-#    [resources.database]
-#     type = "mysql"
-#     type = "postgresql"

--- a/manifest.toml
+++ b/manifest.toml
@@ -52,7 +52,7 @@ ram.runtime = "50M"
     [install.db_type]
      ask.fr = "quel moteur de base de données souhaitez-vous"
      ask.en = "which data base engine do you prefer"
-     help.fr : "Si vous ne savez pas quoi choisir, c'est que ça n'a aucune importance;"
+     help.fr = "Si vous ne savez pas quoi choisir, c'est que ça n'a aucune importance;"
      help.en = "If you don't know what to choose ... don't choose ;-) "
      type = "select"
      choices = ["mysql","postgresql"]
@@ -60,7 +60,7 @@ ram.runtime = "50M"
 
     [install.tb_prefix]
      ask.fr = "voulez-vous utiliser un préfixe de table différent du défaut (galette_)?"
-     ask.help = "si oui, veillez à le terminer par un _ ('souligné', 'tiret du 8',...)
+     ask.help = "si oui, veillez à le terminer par un _ ('souligné', 'tiret du 8',...)"
      type = "string"
      default = "galette_"
  

--- a/manifest.toml
+++ b/manifest.toml
@@ -52,7 +52,7 @@ ram.runtime = "50M"
     [install.db_type]
      ask.fr = "quel moteur de base de données souhaitez-vous"
      ask.en = "which data base engine do you prefer"
-     help.fr : "Si vous ne savez pas quoi chosir, c'est que ça n'a aucune importance;"
+     help.fr : "Si vous ne savez pas quoi choisir, c'est que ça n'a aucune importance;"
      help.en = "If you don't know what to choose ... don't choose ;-) "
      type = "select"
      choices = ["mysql","postgresql"]
@@ -60,7 +60,7 @@ ram.runtime = "50M"
 
     [install.tb_prefix]
      ask.fr = "voulez-vous utiliser un préfixe de table différent du défaut (galette_)?"
-     ask.help = "si oui, veillez à le terminer par un _ ("souligné", "tiret du 8",...)
+     ask.help = "si oui, veillez à le terminer par un _ ('souligné', 'tiret du 8',...)
      type = "string"
      default = "galette_"
  

--- a/manifest.toml
+++ b/manifest.toml
@@ -86,10 +86,9 @@ ram.runtime = "50M"
     packages = "php8.3-tidy, php8.3-intl, php8.3-mbstring, php8.3-xml, php8.3-gd, php8.3-curl"
     packages_from_raw_bash = """
        if [[ "$db_type" == "mysql" ]]; then 
-   	  echo "mariadb-server, php8.3-mysql"
-       fi
+   	    echo "mariadb-server, php8.3-mysql"
        elif [[ "$db_type" == "postgresql" ]]; then
-            echo "postgresql, php8.3-pgsql"
+        echo "postgresql, php8.3-pgsql"
        fi
     """
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -47,7 +47,7 @@ ram.runtime = "50M"
     type = "user"
 
     [install.password]
-    type = "password"
+    type = "string"
 
     [install.db_type]
      ask.fr = "quel moteur de base de données souhaitez-vous"
@@ -60,7 +60,7 @@ ram.runtime = "50M"
 
     [install.tb_prefix]
      ask.fr = "voulez-vous utiliser un préfixe de table différent du défaut (galette_)?"
-     ask.help = "si oui, veillez à le terminer par un _ ('souligné', 'tiret du 8',...)"
+     ask.help = "n'est utile que dans des cas très particuliers"
      type = "string"
      default = "galette_"
  

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Galette"
 description.en = "Membership management web application for non profit organizations"
 description.fr = "Outil de gestion d'adhérents et de cotisation en ligne pour associations"
 
-version = "1.1.3~ynh1"
+version = "1.1.3~ynh2"
 
 maintainers = []
 
@@ -49,6 +49,22 @@ ram.runtime = "50M"
     [install.password]
     type = "password"
 
+    [install.db_type]
+     ask.fr = "quel moteur de base de données souhaitez-vous"
+     ask.en = "which data base engine do you prefer"
+     help.fr : "Si vous ne savez pas quoi chosir, c'est que ça n'a aucune importance;"
+     help.en = "If you don't know what to choose ... don't choose ;-) "
+     type = "select"
+     choices = ["mysql","postgresql"]
+     default = "postgresql"
+
+    [install.tb_prefix]
+     ask.fr = "voulez-vous utiliser un préfixe de table différent du défaut (galette_)?"
+     ask.help = "si oui, veillez à le terminer par un _ ("souligné", "tiret du 8",...)
+     type = "string"
+     default = "galette_"
+ 
+
 [resources]
     [resources.sources.main]
     url = "https://www.galette.eu/download/galette-1.1.3.tar.bz2"
@@ -66,7 +82,19 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "postgresql, php8.3-tidy, php8.3-intl, php8.3-mbstring, php8.3-xml, php8.3-gd, php8.3-curl, php8.3-pgsql"
+    
+    packages = "php8.3-tidy, php8.3-intl, php8.3-mbstring, php8.3-xml, php8.3-gd, php8.3-curl"
+    packages_from_raw_bash = """
+       if [[ "$db_type" == "mysql" ]]; then 
+   	  echo "mariadb-server, php8.3-mysql"
+       fi
+       elif [[ "$db_type" == "postgresql" ]]; then
+            echo "postgresql, php8.3-pgsql"
+       fi
+    """
 
-    [resources.database]
-    type = "postgresql"
+
+# seulement une de ces lignes est possible. Peut-on faire ça par un test ? ou suffit-il d'initialiser la base dans le scriot d'install ?
+#    [resources.database]
+#     type = "mysql"
+#     type = "postgresql"

--- a/manifest.toml
+++ b/manifest.toml
@@ -47,7 +47,9 @@ ram.runtime = "50M"
     type = "user"
 
     [install.password]
-    type = "string"
+    type = "password"
+    help.fr = "pas besoin que ce soit le même que pour yunohost. ATTENTION : pas de caractères spéciaux dans le mot de passe, ça ne marche pas (encore); "
+    help.en = "it's not necessary to use the samme pw as for yunohost. WARNING : nos special char in this passord, there is (still) a bug with"
 
     [install.db_type]
      ask.fr = "quel moteur de base de données souhaitez-vous"

--- a/scripts/backup
+++ b/scripts/backup
@@ -36,7 +36,11 @@ ynh_backup --src_path="/etc/logrotate.d/$app"
 #=================================================
 ynh_print_info --message="Backing up the PostgreSQL database..."
 
-ynh_psql_dump_db --database="$db_name" > db.sql
+if [ $db_type == "mysql" ]; then
+ ynh_mysql_dump_db --database="$db_name" > db.sql
+elif [ $db_type == "postgresql" ]; then
+ ynh_psql_dump_db --database="$db_name" > db.sql
+fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -27,7 +27,8 @@ chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
-# DATA BASE CREATION (not done via ressources_database
+# DATA BASE CREATION
+# as we want to choose the database engine, we cannot rely on manifest to do this
 #=================================================
 ynh_script_progression --message="créating data base for $app..." --weight=1
     db_name=$(ynh_sanitize_dbid --db_name=$app)
@@ -58,19 +59,6 @@ ynh_add_nginx_config
 ynh_use_logrotate
 
 #=================================================
-# SPECIFIC SETUP
-#=================================================
-# ADD A CONFIGURATION
-# suppress to let galette create it it's proper way
-#=================================================
-#ynh_script_progression --message="Adding a configuration file..." --weight=1
-
-#ynh_add_config --template="config.inc.php" --destination="$install_dir/galette/config/config.inc.php"
-
-#chmod 400 "$install_dir/galette/config/config.inc.php"
-#chown $app:$app "$install_dir/galette/config/config.inc.php"
-
-#=================================================
 # SETUP APPLICATION WITH CURL
 #=================================================
 ynh_script_progression --message="Setuping application with CURL..."
@@ -89,6 +77,7 @@ ynh_local_curl "/installer.php"  "install_type=i"
 ynh_local_curl "/installer.php"  "install_dbtype=$db_type" "install_dbhost=localhost" "install_dbport=$db_port" "install_dbuser=$db_user" "install_dbpass=$db_pwd" "install_dbname=$db_name" "install_dbprefix=$tb_prefix"
 ynh_local_curl "/installer.php"  "install_dbperms_ok=1"
 ynh_local_curl "/installer.php"  "install_dbwrite_ok=1"
+password=`jq -Rj @uri <<<$password` #to escape special characters that may appear in a password
 ynh_local_curl "/installer.php"  "install_adminlogin=$admin" "install_adminpass=$password" "install_adminpass_verif=$password"
 ynh_local_curl "/installer.php"  "install_telemetry_ok=1"
 ynh_local_curl "/installer.php"  "install_prefs_ok=1"

--- a/scripts/install
+++ b/scripts/install
@@ -90,6 +90,7 @@ ynh_local_curl "/installer.php"  "install_dbtype=$db_type" "install_dbhost=local
 ynh_local_curl "/installer.php"  "install_dbperms_ok=1"
 ynh_local_curl "/installer.php"  "install_dbwrite_ok=1"
 ynh_local_curl "/installer.php"  "install_adminlogin=$admin" "install_adminpass=$password" "install_adminpass_verif=$password"
+ynh_local_curl "/installer.php"  "install_telemetry_ok=1"
 ynh_local_curl "/installer.php"  "install_prefs_ok=1"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -27,6 +27,23 @@ chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
+# DATA BASE CREATION (not done via ressources_database
+#=================================================
+ynh_script_progression --message="icréating data base for $app..." --weight=1
+    db_name=$(ynh_sanitize_dbid --db_name=$app)
+    db_user=$db_name
+    db_pwd=$(ynh_string_random --length=30)
+    ynh_app_setting_set --app=$app --key=db_name --value=$db_name
+    ynh_app_setting_set --app=$app --key=db_user --value=$db_user
+    ynh_app_setting_set --app=$app --key=db_pwd --value=$db_pwd
+
+    if [ $db_type == "mysql" ]; then
+        ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
+    elif [ $db_type == "postgresql" ]; then
+        ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
+    fi
+
+#=================================================
 # SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression --message="Adding system configurations related to $app..." --weight=1
@@ -44,24 +61,32 @@ ynh_use_logrotate
 # SPECIFIC SETUP
 #=================================================
 # ADD A CONFIGURATION
+# suppress to let galette create it it's proper way
 #=================================================
-ynh_script_progression --message="Adding a configuration file..." --weight=1
+#ynh_script_progression --message="Adding a configuration file..." --weight=1
 
-ynh_add_config --template="config.inc.php" --destination="$install_dir/galette/config/config.inc.php"
+#ynh_add_config --template="config.inc.php" --destination="$install_dir/galette/config/config.inc.php"
 
-chmod 400 "$install_dir/galette/config/config.inc.php"
-chown $app:$app "$install_dir/galette/config/config.inc.php"
+#chmod 400 "$install_dir/galette/config/config.inc.php"
+#chown $app:$app "$install_dir/galette/config/config.inc.php"
 
 #=================================================
 # SETUP APPLICATION WITH CURL
 #=================================================
 ynh_script_progression --message="Setuping application with CURL..."
 
+    if [ $db_type == "mysql" ]; then
+        db_port="3306"
+    elif [ $db_type == "postgresql" ]; then
+        db_port="5432"
+    fi
+
+
 # Installation with curl
 ynh_script_progression --message="Finalizing installation..."
 ynh_local_curl "/installer.php" "install_permsok=1"
 ynh_local_curl "/installer.php"  "install_type=i"
-ynh_local_curl "/installer.php"  "install_dbtype=pgsql" "install_dbhost=localhost" "install_dbport=5432" "install_dbuser=$db_user" "install_dbpass=$db_pwd" "install_dbname=$db_name" "install_dbprefix=galette_"
+ynh_local_curl "/installer.php"  "install_dbtype=$db_type" "install_dbhost=localhost" "install_dbport=$db_port" "install_dbuser=$db_user" "install_dbpass=$db_pwd" "install_dbname=$db_name" "install_dbprefix=$tb_prefix"
 ynh_local_curl "/installer.php"  "install_dbperms_ok=1"
 ynh_local_curl "/installer.php"  "install_dbwrite_ok=1"
 ynh_local_curl "/installer.php"  "install_adminlogin=$admin" "install_adminpass=$password" "install_adminpass_verif=$password"

--- a/scripts/install
+++ b/scripts/install
@@ -29,7 +29,7 @@ chown -R $app:www-data "$install_dir"
 #=================================================
 # DATA BASE CREATION (not done via ressources_database
 #=================================================
-ynh_script_progression --message="icréating data base for $app..." --weight=1
+ynh_script_progression --message="créating data base for $app..." --weight=1
     db_name=$(ynh_sanitize_dbid --db_name=$app)
     db_user=$db_name
     db_pwd=$(ynh_string_random --length=30)

--- a/scripts/remove
+++ b/scripts/remove
@@ -10,6 +10,20 @@ source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
+#Remove the data base
+#=================================================
+ynh_script_progression --message="Removing the database..." --weight=2
+
+db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+db_user=$db_name
+
+if [ $db_type == "mysql" ]; then
+        ynh_mysql_remove_db --db_user=$db_user --db_name=$db_name
+elif [ $db_type == "postgresql" ]; then
+        ynh_psql_remove_db --db_user=$db_user --db_name=$db_name
+fi
+
+#=================================================
 # REMOVE SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression --message="Removing system configurations related to $app..." --weight=1

--- a/scripts/restore
+++ b/scripts/restore
@@ -31,7 +31,11 @@ chown -R $app:www-data "$install_dir"
 #=================================================
 ynh_script_progression --message="Restoring the PostgreSQL database..." --weight=1
 
-ynh_psql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+if [ $db_type == "mysql" ]; then
+ ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+elif [ $db_type == "postgresql" ]; then
+ ynh_psql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+fi
 
 #=================================================
 # RESTORE SYSTEM CONFIGURATIONS

--- a/scripts/restore
+++ b/scripts/restore
@@ -27,14 +27,21 @@ chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
-# RESTORE THE POSTGRESQL DATABASE
+# RESTORE THE DATABASE
 #=================================================
-ynh_script_progression --message="Restoring the PostgreSQL database..." --weight=1
+ynh_script_progression --message="Restoring the database..." --weight=1
 
-if [ $db_type == "mysql" ]; then
- ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
-elif [ $db_type == "postgresql" ]; then
- ynh_psql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+    db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+    db_user=$db_name
+    db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
+
+    if [ $db_type == "mysql" ]; then
+        ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
+        ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+    elif [ $db_type == "postgresql" ]; then
+        ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
+        ynh_psql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+    fi
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,7 +20,7 @@ timezone="$(cat /etc/timezone)"
 #=================================================
 ynh_script_progression --message="Upgrading source files..."
 
-ynh_setup_source --dest_dir="$install_dir" --keep="galette/config/config.inc.php galette/data galette/plugins"
+ynh_setup_source --dest_dir="$install_dir" --keep="galette/config galette/data galette/plugins"
 
 chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"


### PR DESCRIPTION
## Problem
The actual package imposes the use of postgresql, which may be not convenient, e.g. if you want to port from another install, or if you need to work directly on the data base for special purposes (testing of exports formulae for example), which is muche easier with phpmyadmin than with pgAdmin I think.

## Solution

I added the choice of the data base engine in manifest and handle the data base creation and destruction in install, remove, upgrade, backup, ...

In the meanwhile I corrected a bug in the package, a call to curl with parameter telemetry was missing, which caused the configuration file not to be wrtitten at install. That's why a custom config.inc.php was copied at install, which is no more requiered, galette does it better :-)

Futhermore, the method used to pass superadmin password ti the curl command failed when there were special characters in the password. I found a workaround, but thay may be a better one.

Finally I modify the "keep" options while upgrading to preserve the whole config directory which may contain other sensible personalized files than just config.inc.php (exports.xml ou exports.yaml for example).

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

I think I'm not a member, I didnt't try to run the automatic tests.

Hope this helps
Alain