### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -7,7 +7,7 @@ source /usr/share/yunohost/helpers
 # RETRIEVE ARGUMENTS FROM THE MANIFEST
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/restore
+++ b/scripts/restore
@@ -3,7 +3,7 @@
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # RESTORE THE APP MAIN DIR

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -3,7 +3,7 @@
 source _common.sh
 source /usr/share/yunohost/helpers
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.